### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "openSUSE/ap4rc",
+    "name": "opensuse/ap4rc",
     "type": "roundcube-plugin",
     "description": "Roundcube plugin to generate and save application specific passwords",
     "keywords": ["mail","application","password"],
@@ -9,12 +9,10 @@
     "authors": [
         {
             "name": "darix",
-            "email": "",
             "homepage": "https://github.com/darix"
         },
 		{
 			"name": "J. Daniel Schmidt",
-			"email": "",
 			"homepage": "http://jdsn.de"
         }
     ],


### PR DESCRIPTION
- Composer doesn't seem to like blank email address.
- Composer doesn't like upper case characters in package name.

```
root:/srv/roundcube/plugins/ap4rc# composer install

In Factory.php line 319:

  "./composer.json" does not match the expected JSON schema:
   - name : Does not match the regex pattern ^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$
   - authors[0].email : Invalid email
   - authors[1].email : Invalid email

```